### PR TITLE
chore: migrate to .NET 10 with integration tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,21 +3,21 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "commands": [
         "dotnet-cake"
       ],
       "rollForward": false
     },
     "csharpier": {
-      "version": "0.30.6",
+      "version": "1.2.4",
       "commands": [
-        "dotnet-csharpier"
+        "csharpier"
       ],
       "rollForward": false
     },
     "aspire.cli": {
-      "version": "9.3.0-preview.1.25265.20",
+      "version": "13.1.0",
       "commands": [
         "aspire"
       ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Install .NET SDK"
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.201
+          dotnet-version: 10.0.x
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
     <None Include="$(RepoRoot)\assets\logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -32,7 +32,6 @@ Task("Build")
         DotNetBuild(".", new DotNetBuildSettings
         {
             Configuration = configuration,
-            OutputDirectory = artefactsDirectory,
         });
     });
 

--- a/mcp-template-dotnet.slnx
+++ b/mcp-template-dotnet.slnx
@@ -16,4 +16,7 @@
     <Project Path="src/templates/content/MCPServerHybrid/MCPServerHybrid.csproj" />
     <Project Path="src/templates/templates.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Mcp.Template.Tests/Mcp.Template.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>7b323f70-da5a-446a-a7bd-1120c3b8e3d6</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
   </ItemGroup>
 
 

--- a/samples/AppHostHybrid/AppHostHybrid.csproj
+++ b/samples/AppHostHybrid/AppHostHybrid.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>7b323f70-da5a-446a-a7bd-1120c3b8e3d6</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
   </ItemGroup>
 
 

--- a/samples/AppHostRemote/AppHostRemote.csproj
+++ b/samples/AppHostRemote/AppHostRemote.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>7b323f70-da5a-446a-a7bd-1120c3b8e3d6</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Inspector.Aspire.Hosting/Inspector.Aspire.Hosting.csproj
+++ b/src/Inspector.Aspire.Hosting/Inspector.Aspire.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Follow the instructions on
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="9.5.0" />
-    <PackageReference Include="Aspire.Hosting.NodeJS" Version="9.5.0" />
+    <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.NodeJS" Version="9.5.2" />
   </ItemGroup>
 
   <!-- https://github.com/NuGet/Home/issues/8843 -->

--- a/src/Inspector.Aspire.Hosting/Inspector.Aspire.Hosting.csproj
+++ b/src/Inspector.Aspire.Hosting/Inspector.Aspire.Hosting.csproj
@@ -7,7 +7,6 @@
     <!-- Follow the instructions on
     https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
     <PackageId>Nall.ModelContextProtocol.Inspector.Aspire.Hosting</PackageId>
-    <PackageVersion>0.7.0</PackageVersion>
     <Title>Nall.ModelContextProtocol.Inspector.Aspire.Hosting</Title>
     <Authors>Nikiforov Oleksii</Authors>
     <Description>MCP Inspector</Description>

--- a/src/templates/content/MCPServer/MCPServer.csproj
+++ b/src/templates/content/MCPServer/MCPServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -30,8 +30,8 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/templates/content/MCPServerAuth/MCPServerAuth.csproj
+++ b/src/templates/content/MCPServerAuth/MCPServerAuth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>a7adc670-95cb-4df9-ae27-7974339bbc25</UserSecretsId>

--- a/src/templates/content/MCPServerHybrid/MCPServerHybrid.csproj
+++ b/src/templates/content/MCPServerHybrid/MCPServerHybrid.csproj
@@ -30,7 +30,6 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
   </ItemGroup>

--- a/src/templates/content/MCPServerHybrid/MCPServerHybrid.csproj
+++ b/src/templates/content/MCPServerHybrid/MCPServerHybrid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -30,9 +30,9 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/templates/content/MCPServerRemote/MCPServerRemote.csproj
+++ b/src/templates/content/MCPServerRemote/MCPServerRemote.csproj
@@ -30,7 +30,6 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
   </ItemGroup>

--- a/src/templates/content/MCPServerRemote/MCPServerRemote.csproj
+++ b/src/templates/content/MCPServerRemote/MCPServerRemote.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -30,9 +30,9 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/templates/templates.csproj
+++ b/src/templates/templates.csproj
@@ -11,7 +11,7 @@
 
     <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>

--- a/src/templates/templates.csproj
+++ b/src/templates/templates.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- Follow the instructions on https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
     <PackageId>Nall.ModelContextProtocol.Template</PackageId>
-    <PackageVersion>0.9.1</PackageVersion>
     <Title>Nall.ModelContextProtocol.Template</Title>
     <Authors>Nikiforov Oleksii</Authors>
     <Description>MCP templates</Description>

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,22 @@
+# Test project specific settings
+# Inherits from root .editorconfig
+
+##########################################
+# Test-specific rule suppressions
+##########################################
+
+[*.cs]
+
+# CA1707: Identifiers should not contain underscores
+# Suppressed: Test methods use Method_Scenario_Expected naming convention
+# Example: MCPServer_ListTools_ReturnsEchoTool
+dotnet_diagnostic.CA1707.severity = none
+
+# CA1001: Types that own disposable fields should be disposable
+# Suppressed: Test classes use xUnit's IAsyncLifetime.DisposeAsync() for cleanup
+# instead of implementing IDisposable directly
+dotnet_diagnostic.CA1001.severity = none
+
+# CA1852: Type can be sealed because it has no subtypes
+# Suppressed: Test helper types (records, classes) don't need sealing
+dotnet_diagnostic.CA1852.severity = none

--- a/tests/Mcp.Template.Tests/AspireBuildTests.cs
+++ b/tests/Mcp.Template.Tests/AspireBuildTests.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+
+namespace Mcp.Template.Tests;
+
+/// <summary>
+/// Checkpoint 2: Verify Aspire AppHost projects build successfully
+/// </summary>
+public class AspireBuildTests
+{
+    private static readonly string SolutionRoot = TestHelpers.GetSolutionRoot();
+
+    [Fact]
+    public async Task AppHost_Builds_Successfully()
+    {
+        var projectPath = Path.Combine(SolutionRoot, "samples", "AppHost", "AppHost.csproj");
+        var result = await BuildProjectAsync(projectPath);
+
+        Assert.True(
+            result.Success,
+            $"Build failed with exit code {result.ExitCode}:\n{result.Output}"
+        );
+    }
+
+    [Fact]
+    public async Task AppHostHybrid_Builds_Successfully()
+    {
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "samples",
+            "AppHostHybrid",
+            "AppHostHybrid.csproj"
+        );
+        var result = await BuildProjectAsync(projectPath);
+
+        Assert.True(
+            result.Success,
+            $"Build failed with exit code {result.ExitCode}:\n{result.Output}"
+        );
+    }
+
+    [Fact]
+    public async Task AppHostRemote_Builds_Successfully()
+    {
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "samples",
+            "AppHostRemote",
+            "AppHostRemote.csproj"
+        );
+        var result = await BuildProjectAsync(projectPath);
+
+        Assert.True(
+            result.Success,
+            $"Build failed with exit code {result.ExitCode}:\n{result.Output}"
+        );
+    }
+
+    private static async Task<BuildResult> BuildProjectAsync(string projectPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"build \"{projectPath}\" --no-restore -v q",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)!;
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return new BuildResult(
+            process.ExitCode == 0,
+            process.ExitCode,
+            string.IsNullOrEmpty(error) ? output : $"{output}\n{error}"
+        );
+    }
+
+    private record BuildResult(bool Success, int ExitCode, string Output);
+}

--- a/tests/Mcp.Template.Tests/AuthServerTests.cs
+++ b/tests/Mcp.Template.Tests/AuthServerTests.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace Mcp.Template.Tests;
+
+/// <summary>
+/// Checkpoint 4: Tests for authenticated MCP servers (MCPServerAuth)
+/// Verifies server enforces authentication and returns 401 Unauthorized
+/// </summary>
+public class AuthServerTests : IAsyncLifetime
+{
+    private static readonly string SolutionRoot = TestHelpers.GetSolutionRoot();
+    private Process? _serverProcess;
+    private HttpClient? _httpClient;
+    private int _port;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        _httpClient?.Dispose();
+
+        if (_serverProcess is { HasExited: false })
+        {
+            _serverProcess.Kill(entireProcessTree: true);
+            await _serverProcess.WaitForExitAsync();
+        }
+
+        _serverProcess?.Dispose();
+    }
+
+    [Fact]
+    public async Task MCPServerAuth_WithoutCredentials_Returns401()
+    {
+        // Arrange
+        _port = GetAvailablePort();
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerAuth"
+        );
+
+        _serverProcess = StartServer(projectPath, _port);
+        _httpClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{_port}") };
+
+        await WaitForServerAsync(_httpClient, TimeSpan.FromSeconds(30));
+
+        // MCP initialize request (JSON-RPC 2.0) without auth
+        var initRequest = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2025-03-26",
+                capabilities = new { },
+                clientInfo = new { name = "TestClient", version = "1.0.0" },
+            },
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(initRequest),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/") { Content = content };
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json")
+        );
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream")
+        );
+
+        // Act
+        var response = await _httpClient.SendAsync(request);
+
+        // Assert - Should return 401 Unauthorized (no auth token provided)
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MCPServerAuth_WithoutCredentials_ReturnsWwwAuthenticate()
+    {
+        // Arrange
+        _port = GetAvailablePort();
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerAuth"
+        );
+
+        _serverProcess = StartServer(projectPath, _port);
+        _httpClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{_port}") };
+
+        await WaitForServerAsync(_httpClient, TimeSpan.FromSeconds(30));
+
+        var initRequest = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2025-03-26",
+                capabilities = new { },
+                clientInfo = new { name = "TestClient", version = "1.0.0" },
+            },
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(initRequest),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/") { Content = content };
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json")
+        );
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream")
+        );
+
+        // Act
+        var response = await _httpClient.SendAsync(request);
+
+        // Assert - Should include WWW-Authenticate header with MCP auth scheme
+        Assert.True(
+            response.Headers.WwwAuthenticate.Count > 0,
+            "Expected WWW-Authenticate header in 401 response"
+        );
+    }
+
+    private static Process StartServer(string projectPath, int port)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"run --project \"{projectPath}\" -v q -- --urls http://localhost:{port}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        // Set required Azure AD config via environment variables
+        psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
+        psi.Environment["McpServerUrl"] = $"http://localhost:{port}";
+        psi.Environment["AzureAd__Instance"] = "https://login.microsoftonline.com/";
+        psi.Environment["AzureAd__TenantId"] = "00000000-0000-0000-0000-000000000000";
+        psi.Environment["AzureAd__ClientId"] = "00000000-0000-0000-0000-000000000001";
+        psi.Environment["AzureAd__Audience"] = "api://00000000-0000-0000-0000-000000000001";
+
+        return Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start server process");
+    }
+
+    private static async Task WaitForServerAsync(HttpClient client, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            try
+            {
+                using var socket = new System.Net.Sockets.TcpClient();
+                await socket.ConnectAsync(client.BaseAddress!.Host, client.BaseAddress.Port);
+                return;
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // Server not ready yet
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException($"Server did not start within {timeout}");
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/Mcp.Template.Tests/HttpServerTests.cs
+++ b/tests/Mcp.Template.Tests/HttpServerTests.cs
@@ -1,0 +1,223 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace Mcp.Template.Tests;
+
+/// <summary>
+/// Checkpoint 3: Tests for HTTP-based MCP servers (MCPServerRemote)
+/// Uses Streamable HTTP transport (2025-03-26 spec) instead of deprecated SSE
+/// </summary>
+public class HttpServerTests : IAsyncLifetime
+{
+    private static readonly string SolutionRoot = TestHelpers.GetSolutionRoot();
+    private Process? _serverProcess;
+    private HttpClient? _httpClient;
+    private int _port;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        _httpClient?.Dispose();
+
+        if (_serverProcess is { HasExited: false })
+        {
+            _serverProcess.Kill(entireProcessTree: true);
+            await _serverProcess.WaitForExitAsync();
+        }
+
+        _serverProcess?.Dispose();
+    }
+
+    [Fact]
+    public async Task MCPServerRemote_StreamableHttp_AcceptsInitialize()
+    {
+        // Arrange
+        _port = GetAvailablePort();
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerRemote"
+        );
+
+        _serverProcess = StartServer(projectPath, _port);
+        _httpClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{_port}") };
+
+        await WaitForServerAsync(_httpClient, TimeSpan.FromSeconds(30));
+
+        // MCP initialize request (JSON-RPC 2.0)
+        var initRequest = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2025-03-26",
+                capabilities = new { },
+                clientInfo = new { name = "TestClient", version = "1.0.0" },
+            },
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(initRequest),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        // Act - POST to root for Streamable HTTP transport
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/") { Content = content };
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json")
+        );
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream")
+        );
+
+        var response = await _httpClient.SendAsync(request);
+
+        // Assert - Server accepts and processes the request
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Contains("protocolVersion", responseBody);
+        Assert.Contains("serverInfo", responseBody);
+    }
+
+    [Fact]
+    public async Task MCPServerRemote_StreamableHttp_ListsTools()
+    {
+        // Arrange
+        _port = GetAvailablePort();
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerRemote"
+        );
+
+        _serverProcess = StartServer(projectPath, _port);
+        _httpClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{_port}") };
+
+        await WaitForServerAsync(_httpClient, TimeSpan.FromSeconds(30));
+
+        // Initialize first
+        var initRequest = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2025-03-26",
+                capabilities = new { },
+                clientInfo = new { name = "TestClient", version = "1.0.0" },
+            },
+        };
+
+        var initContent = new StringContent(
+            JsonSerializer.Serialize(initRequest),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var initReq = new HttpRequestMessage(HttpMethod.Post, "/") { Content = initContent };
+        initReq.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json")
+        );
+        initReq.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream")
+        );
+
+        var initResponse = await _httpClient.SendAsync(initReq);
+        initResponse.Headers.TryGetValues("mcp-session-id", out var sessionIds);
+        var sessionId = sessionIds?.FirstOrDefault();
+
+        // List tools request
+        var listToolsRequest = new
+        {
+            jsonrpc = "2.0",
+            id = 2,
+            method = "tools/list",
+        };
+
+        var listContent = new StringContent(
+            JsonSerializer.Serialize(listToolsRequest),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/") { Content = listContent };
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json")
+        );
+        request.Headers.Accept.Add(
+            new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream")
+        );
+        if (sessionId is not null)
+            request.Headers.Add("mcp-session-id", sessionId);
+
+        // Act
+        var response = await _httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Contains("tools", responseBody);
+        Assert.Contains("Echo", responseBody);
+    }
+
+    private static Process StartServer(string projectPath, int port)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"run --project \"{projectPath}\" -v q -- --urls http://localhost:{port}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        return Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start server process");
+    }
+
+    private static async Task WaitForServerAsync(HttpClient client, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            try
+            {
+                // Try to connect to TCP port to verify server is listening
+                using var socket = new System.Net.Sockets.TcpClient();
+                await socket.ConnectAsync(client.BaseAddress!.Host, client.BaseAddress.Port);
+                return; // Server is listening
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // Server not ready yet
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException($"Server did not start within {timeout}");
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/Mcp.Template.Tests/Mcp.Template.Tests.csproj
+++ b/tests/Mcp.Template.Tests/Mcp.Template.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.TemplateEngine.Authoring.TemplateVerifier" Version="10.0.101" />
+    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Mcp.Template.Tests/StdioServerTests.cs
+++ b/tests/Mcp.Template.Tests/StdioServerTests.cs
@@ -1,0 +1,159 @@
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Mcp.Template.Tests;
+
+/// <summary>
+/// Checkpoint 1: Tests for stdio-based MCP servers (MCPServer, MCPServerHybrid --stdio)
+/// </summary>
+public class StdioServerTests : IAsyncLifetime
+{
+    private static readonly string SolutionRoot = GetSolutionRoot();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task MCPServer_ListTools_ReturnsEchoTool()
+    {
+        // Arrange
+        var projectPath = Path.Combine(SolutionRoot, "src", "templates", "content", "MCPServer");
+
+        await using var client = await McpClient.CreateAsync(
+            new StdioClientTransport(
+                new StdioClientTransportOptions
+                {
+                    Name = "MCPServer",
+                    Command = "dotnet",
+                    Arguments = ["run", "--project", projectPath, "-v", "q"],
+                }
+            )
+        );
+
+        // Act
+        var tools = await client.ListToolsAsync();
+
+        // Assert
+        Assert.NotEmpty(tools);
+        Assert.Contains(tools, t => t.Name == "echo_hello");
+    }
+
+    [Fact]
+    public async Task MCPServer_CallEchoTool_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var projectPath = Path.Combine(SolutionRoot, "src", "templates", "content", "MCPServer");
+
+        await using var client = await McpClient.CreateAsync(
+            new StdioClientTransport(
+                new StdioClientTransportOptions
+                {
+                    Name = "MCPServer",
+                    Command = "dotnet",
+                    Arguments = ["run", "--project", projectPath, "-v", "q"],
+                }
+            )
+        );
+
+        // Act
+        var result = await client.CallToolAsync(
+            "echo_hello",
+            new Dictionary<string, object?> { ["message"] = "world" }
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Content);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Contains("hello world", textContent.Text);
+    }
+
+    [Fact]
+    public async Task MCPServerHybrid_Stdio_ListTools_ReturnsEchoTool()
+    {
+        // Arrange
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerHybrid"
+        );
+
+        await using var client = await McpClient.CreateAsync(
+            new StdioClientTransport(
+                new StdioClientTransportOptions
+                {
+                    Name = "MCPServerHybrid",
+                    Command = "dotnet",
+                    Arguments = ["run", "--project", projectPath, "-v", "q", "--", "--stdio"],
+                }
+            )
+        );
+
+        // Act
+        var tools = await client.ListToolsAsync();
+
+        // Assert
+        Assert.NotEmpty(tools);
+        // MCPServerHybrid uses "echo" as tool name (method name without explicit Name property)
+        Assert.Contains(tools, t => t.Name == "echo");
+    }
+
+    [Fact]
+    public async Task MCPServerHybrid_Stdio_CallEchoTool_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var projectPath = Path.Combine(
+            SolutionRoot,
+            "src",
+            "templates",
+            "content",
+            "MCPServerHybrid"
+        );
+
+        await using var client = await McpClient.CreateAsync(
+            new StdioClientTransport(
+                new StdioClientTransportOptions
+                {
+                    Name = "MCPServerHybrid",
+                    Command = "dotnet",
+                    Arguments = ["run", "--project", projectPath, "-v", "q", "--", "--stdio"],
+                }
+            )
+        );
+
+        // Act - MCPServerHybrid uses "echo" as tool name
+        var result = await client.CallToolAsync(
+            "echo",
+            new Dictionary<string, object?> { ["message"] = "test" }
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Content);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Contains("hello test", textContent.Text);
+    }
+
+    private static string GetSolutionRoot()
+    {
+        // Path from bin/Debug/net10.0 -> solution root (5 levels up)
+        // tests/Mcp.Template.Tests/bin/Debug/net10.0 -> solution
+        var assemblyDir = AppContext.BaseDirectory;
+        var current = new DirectoryInfo(assemblyDir);
+
+        // Walk up looking for .sln or .slnx file (new XML solution format)
+        while (current != null)
+        {
+            if (current.GetFiles("*.sln").Length > 0 || current.GetFiles("*.slnx").Length > 0)
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not find solution root from {assemblyDir}");
+    }
+}

--- a/tests/Mcp.Template.Tests/StdioServerTests.cs
+++ b/tests/Mcp.Template.Tests/StdioServerTests.cs
@@ -8,7 +8,7 @@ namespace Mcp.Template.Tests;
 /// </summary>
 public class StdioServerTests : IAsyncLifetime
 {
-    private static readonly string SolutionRoot = GetSolutionRoot();
+    private static readonly string SolutionRoot = TestHelpers.GetSolutionRoot();
 
     public Task InitializeAsync() => Task.CompletedTask;
 
@@ -137,23 +137,5 @@ public class StdioServerTests : IAsyncLifetime
         var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
         Assert.NotNull(textContent);
         Assert.Contains("hello test", textContent.Text);
-    }
-
-    private static string GetSolutionRoot()
-    {
-        // Path from bin/Debug/net10.0 -> solution root (5 levels up)
-        // tests/Mcp.Template.Tests/bin/Debug/net10.0 -> solution
-        var assemblyDir = AppContext.BaseDirectory;
-        var current = new DirectoryInfo(assemblyDir);
-
-        // Walk up looking for .sln or .slnx file (new XML solution format)
-        while (current != null)
-        {
-            if (current.GetFiles("*.sln").Length > 0 || current.GetFiles("*.slnx").Length > 0)
-                return current.FullName;
-            current = current.Parent;
-        }
-
-        throw new InvalidOperationException($"Could not find solution root from {assemblyDir}");
     }
 }

--- a/tests/Mcp.Template.Tests/TestHelpers.cs
+++ b/tests/Mcp.Template.Tests/TestHelpers.cs
@@ -1,0 +1,19 @@
+namespace Mcp.Template.Tests;
+
+internal static class TestHelpers
+{
+    public static string GetSolutionRoot()
+    {
+        var assemblyDir = AppContext.BaseDirectory;
+        var current = new DirectoryInfo(assemblyDir);
+
+        while (current != null)
+        {
+            if (current.GetFiles("*.sln").Length > 0 || current.GetFiles("*.slnx").Length > 0)
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not find solution root from {assemblyDir}");
+    }
+}


### PR DESCRIPTION
## Summary

- Migrate all projects from .NET 9 to .NET 10
- Update Aspire SDK to 13.1.0
- Update CI/CD workflow to use .NET 10.0.x SDK
- Add comprehensive integration test suite

## Test Coverage

| Checkpoint | Tests | Description |
|------------|-------|-------------|
| 1. Stdio | 4 | MCPServer + MCPServerHybrid tool invocation |
| 2. Aspire | 3 | AppHost, AppHostHybrid, AppHostRemote builds |
| 3. HTTP | 2 | MCPServerRemote Streamable HTTP transport |
| 4. Auth | 2 | MCPServerAuth 401 + WWW-Authenticate |

**Total: 11 tests**

## Changes

- `net9.0` → `net10.0` in all project files
- `.github/workflows/build.yml` updated to `dotnet-version: 10.0.x`
- New `tests/Mcp.Template.Tests/` project with:
  - `StdioServerTests.cs` - MCP client/server via stdio
  - `AspireBuildTests.cs` - Aspire AppHost build verification
  - `HttpServerTests.cs` - Streamable HTTP transport (2025-03-26 spec)
  - `AuthServerTests.cs` - Authentication enforcement (401 response)
- `tests/.editorconfig` for test-specific analyzer suppressions

## Test Plan

- [x] All 11 tests pass locally
- [x] CI/CD runs tests on ubuntu-latest and windows-latest